### PR TITLE
Added explicit tilt/erb require, added params helper.

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -1,4 +1,5 @@
 require "tilt"
+require "tilt/erb"
 require "rack/protection"
 require "hobbit"
 require "hobbit/contrib"
@@ -23,6 +24,10 @@ class App < Hobbit::Base
 
   use Rack::Static, root: "public",
                     urls: ["/javascripts", "/stylesheets", "/images"]
+
+  def params
+    request.params
+  end
 
   get "/" do
     render "index"


### PR DESCRIPTION
Hey @etagwerker, 

This PR fixes this warning when rendering an ERB file: 
`WARN: tilt autoloading 'tilt/erb' in a non thread-safe way; explicit require 'tilt/erb' suggested.`
I also added a helper method for easier access to the params hash. 

Please check it out, thanks! 
