### PR TITLE
Use latest byebug, bundled.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem "tilt", "~> 2.0.2"
 group :development do
   gem "shotgun", "~> 0.9.1"
   gem "bundler-audit", "~> 0.5.0"
-  gem "byebug"
+  gem "byebug", "~> 9.0.3"
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ GEM
     bundler-audit (0.5.0)
       bundler (~> 1.2)
       thor (~> 0.18)
-    byebug (8.2.2)
+    byebug (9.0.3)
     dotenv (2.1.0)
     hiredis (0.6.1)
     hobbit (0.6.1)
@@ -37,7 +37,7 @@ PLATFORMS
 
 DEPENDENCIES
   bundler-audit (~> 0.5.0)
-  byebug
+  byebug (~> 9.0.3)
   dotenv (~> 2.1.0)
   hobbit (~> 0.6.1)
   hobbit-contrib (~> 0.7.1)


### PR DESCRIPTION
Hey @etagwerker, 

This PR upgrades the version of `byebug` in Gemfile.lock to 9.0.3, the latest release. Using `byebug` 8.2.2 and Ruby 2.3.0, I'm getting a segmentation fault every time I come across an exception:
`(byebug) params
/Users/maurootonelli/.rvm/gems/ruby-2.3.0@global/gems/did_you_mean-1.0.0/lib/did_you_mean/spell_checkers/name_error_checkers/variable_name_checker.rb:10: [BUG] Segmentation fault at 0x000000000000e5
ruby 2.3.0p0 (2015-12-25 revision 53290) [x86_64-darwin14]`

Please check it out, thanks! 
